### PR TITLE
Make VID/PID global vars passed into CheckDevice()

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,12 @@ Pull this repo.
 
 Click on each of the IDs (ONE AT A TIME! Select more than one and it can crash your device) and type on your keyboard until you get signals from the desired keyboard (for me, this was ID7). Note down the VID and PID.
 
-Once you have this, modify `mac_remapper.ahk` and modify this line: <br>
-`id1 := AHI.GetKeyboardId(<VID>, <PID>, 1)` <br>
+Once you have this, modify `mac_remapper.ahk` and modify these lines:
+```
+;; Replace these with your device's VID and PID
+VID := 0
+PID := 0
+```
 With your VID and PID.
 
 Finally, set `mac_remapper.ahk` to run on startup and you're good to go!

--- a/mac_remapper.ahk
+++ b/mac_remapper.ahk
@@ -8,51 +8,46 @@ InstallKeybdHook
 ; The mac 2008 keyboard has command and alt swapped so AHKInterceptor can fix that
 ; god bless chatgpt for actually explaining this
 AHI := AutoHotInterception()
+
 ;; default values if you boot up unplugged to the device
 cm1 := 0
-id1 := 0
+
+;; Replace these with your device's VID and PID
+VID := 0
+PID := 0
 
 ;; this needs to be run in a loop upon disconnect
 A_MenuMaskKey := "vkE8"
 SetTimer CheckDevice, 1000 ;; making this snappy but not too snappy or it bugs out?
 return
 
-#HotIf cm1 != 0  && cm1.IsActive
-
+#HotIf cm1 != 0 && cm1.IsActive
 #HotIf
 
 ;; chatgpt only gave me the idea of neatly changing things into functions
+CheckDevice() {
+    global AHI, cm1, dev, VID, PID ; global vars
 
-
-CheckDevice(){
-    global AHI, cm1, id1, dev ; global vars
     ;; cm1 is 0 during first connection
     ;; if it isn't active then try reconnecting. forever.
-    if(cm1 == 0 || !cm1.IsActive){
+    if (cm1 == 0 || !cm1.IsActive) {
         ;; get device id code
-        
-		dev := AHI.Instance.GetDeviceId(false, 0x05AC, 0x0204, 1) ;; get new keyboard id
-		;; the device has to exist
-        if(dev != 0){
-        ;     ;; remove old one
-        ;     if(AHI._contextManagers.Has(id1)){
-        ;         AHI.RemoveContextManager(id1)
-        ;     }
-        ;     id1 := dev
-        ;     cm1 := AHI.CreateContextManager(id1)
-        AHI.SubscribeKey(dev, GetKeySC("LAlt"), true, AltEvent)
-        AHI.SubscribeKey(dev, GetKeySC("LWin"), true, WinEvent)
+        dev := AHI.Instance.GetDeviceId(false, VID, PID, 1) ;; get new keyboard id
+
+        ;; the device has to exist
+        if (dev != 0) {
+            AHI.SubscribeKey(dev, GetKeySC("LAlt"), true, AltEvent)
+            AHI.SubscribeKey(dev, GetKeySC("LWin"), true, WinEvent)
         }
 
-        
     }
     return
 }
-AltEvent(state){
-   
+
+AltEvent(state) {
     AHI.SendKeyEvent(dev, GetKeySC("LWin"), state)
 }
-WinEvent(state){
-   
+
+WinEvent(state) {
     AHI.SendKeyEvent(dev, GetKeySC("LAlt"), state)
 }


### PR DESCRIPTION
The docs say to modify `id1` with the device's VID/PID, however, `id1` goes unused in `CheckDevice()`. Instead, the function calls `dev := AHI.Instance.GetDeviceId(false, 0x05AC, 0x0204, 1)` (with that hardcoded value).

Changes:
* make VID/PID global variables to be modified and passed into `CheckDevice` (and updated README to reflect this)
* Removed unused `id1`
* Cleaned up code a bit